### PR TITLE
chore: update default prover url

### DIFF
--- a/crates/stn/src/constants.rs
+++ b/crates/stn/src/constants.rs
@@ -3,6 +3,6 @@ pub const STN_PATH: &str = ".stn";
 pub const TAIKO_NODE_DIRECTORY_NAME: &str = "taiko-node";
 pub const DEFAULT_NETWORK_TIMEOUT: u64 = 10;
 pub const KATLA_RPC_URL: &str = "https://rpc.katla.taiko.xyz";
-pub const DEFAULT_PROVER_URL: &str = "http://taiko-a6-prover.zkpool.io:9876";
+pub const DEFAULT_PROVER_URL: &str = "http://taiko-a6-prover.zkpool.io";
 pub const GITHUB_REPO_USERNAME: &str = "d1onys1us";
 pub const GITHUB_REPO_NAME: &str = "stn";


### PR DESCRIPTION
The ZKPool URL no longer includes the port. Update to remove port.

Reference: https://docs.zkpool.io/guides/how-to-connect-ZKPool/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the default prover URL to enhance connectivity and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->